### PR TITLE
fix: handle filter on first level correctly

### DIFF
--- a/jsonpath.lua
+++ b/jsonpath.lua
@@ -284,7 +284,7 @@ local function eval_ast(ast, obj)
         if obj == nil then
             return nil, 'object is not set'
         end
-        for i = 2, #expr, 2 do
+        for i = 2, #expr do
             -- [1] is "var"
             local member, err = eval_ast(expr[i], obj)
             if member == nil then

--- a/jsonpath.lua
+++ b/jsonpath.lua
@@ -428,7 +428,7 @@ local function match_path(ast, path, parent, obj)
     local ast_key, ast_spec = ast_iter(ast, 0)
     local match = MATCH_PARTIAL
 
-    for _, component in ipairs(path) do
+    for path_index, component in ipairs(path) do
         local match_component = true
         if type(ast_spec) ~= 'table' and ast_spec == '..' then
             -- handle descendant switch upfront so descendant
@@ -469,6 +469,15 @@ local function match_path(ast, path, parent, obj)
             else
                 -- 'normal' component name
                 match_component = tostring(component) == tostring(ast_spec)
+            end
+        end
+
+        -- apply filter upfront if it belongs to the currently observing component.
+        if path_index == #path and ast_spec ~= "array" and match_component then
+            local _, next_ast_spec = next(ast, ast_key)
+            if next_ast_spec ~= nil and next_ast_spec[1] == 'filter' then
+                match_component = eval_ast(next_ast_spec, obj) and true or false
+                ast_key, ast_spec = ast_iter(ast, ast_key)
             end
         end
 

--- a/test/test.lua
+++ b/test/test.lua
@@ -710,6 +710,37 @@ testQuery = {
         lu.assertNil(result)
         lu.assertNotNil(err)
     end,
+
+    testFilterFirstLevel = function ()
+        local data = {
+            numeric = 0,
+            string = "0"
+        }
+        local result, err = jp.query(data, "$[?(@.numeric == 0)]")
+        lu.assertEquals(result, {data})
+        lu.assertNil(err)
+
+        local result, err = jp.query(data, '$[?(@.string == "0")]')
+        lu.assertEquals(result, {data})
+        lu.assertNil(err)
+    end,
+
+    testFilterOnNestedArray = function ()
+        local data = {
+            some_unused_key = "",
+            inner = {
+                array = {
+                    {key = 1},
+                    {key = 2},
+                    {key = 3}
+                }
+            }
+        }
+
+        local result, err = jp.query(data, "$..array[?(@.key == 1 || @.key == 2)]")
+        lu.assertItemsEquals(result, {data.inner.array[1], data.inner.array[2]})
+        lu.assertNil(err)
+    end
 }
 
 

--- a/test/test.lua
+++ b/test/test.lua
@@ -725,6 +725,20 @@ testQuery = {
         lu.assertNil(err)
     end,
 
+    testFilterWithDeepPropertyAccessor = function ()
+        local data = {
+            outer = {
+                inner = {
+                    key = 5
+                }
+            }
+        }
+
+        local result, err = jp.query(data, "$[?(@.outer.inner.key == 5)]")
+        lu.assertEquals(result, {data})
+        lu.assertNil(err)
+    end,
+
     testFilterOnNestedArray = function ()
         local data = {
             some_unused_key = "",


### PR DESCRIPTION
Previously, filters on root objects were handled improperly. It fixes them and adds two tests - for that case and additional test for nested array testing just to be sure.