### PR TITLE
Fix filter with compare

### DIFF
--- a/jsonpath.lua
+++ b/jsonpath.lua
@@ -284,6 +284,9 @@ local function eval_ast(ast, obj)
         if obj == nil then
             return nil, 'object is not set'
         end
+        if type(obj) ~= "table" then
+            return nil, 'object is primitive'
+        end
         for i = 2, #expr do
             -- [1] is "var"
             local member, err = eval_ast(expr[i], obj)

--- a/test/test.lua
+++ b/test/test.lua
@@ -802,7 +802,8 @@ testQuery = {
         lu.assertItemsEquals(result, {data.inner.array[1], data.inner.array[2]})
         lu.assertNil(err)
     end,
-    testRecursiveOperatorFilter1 = function()
+    
+    testRecursiveOperatorFilterGT = function()
         local data = {
             photo = {
                 size = 400,

--- a/test/test.lua
+++ b/test/test.lua
@@ -801,7 +801,18 @@ testQuery = {
         local result, err = jp.query(data, "$..array[?(@.key == 1 || @.key == 2)]")
         lu.assertItemsEquals(result, {data.inner.array[1], data.inner.array[2]})
         lu.assertNil(err)
-    end
+    end,
+    testRecursiveOperatorFilter1 = function()
+        local data = {
+            photo = {
+                size = 400,
+            },
+        }
+
+        local result, err = jp.query(data, "$..photo[?(@.size>'400')]")
+        lu.assertItemsEquals(result, {})
+        lu.assertNil(err)
+    end,
 }
 
 


### PR DESCRIPTION
Данный ПР исправляет проблему при которой фильтры вида `$..book[?(@.price>10)]` если `price <= 10`, падали с ошибкой обращения к примитиву как к таблице