### PR TITLE
Grammar rework, adds subscript operator in filters and null literal support

### DIFF
--- a/jsonpath-pico.scm-1.rockspec
+++ b/jsonpath-pico.scm-1.rockspec
@@ -20,7 +20,7 @@ The Lua JsonPath library was written from scratch by Frank Edelhaeuser. It's a p
 }
 dependencies = {
    "lua >= 5.1",
-   "lulpeg ~> pico.0"
+   "lulpeg ~> pico.0.1.3-1"
 }
 build = {
    type = "builtin",


### PR DESCRIPTION
Большой рефакторинг грамматики jsonpath для дальнейшего расширения и приближения к спецификации. 

Коммит
1. Добавляет поддержку выражения expr==null, используя box.NULL или fallback вариант.
2. Добавляет поддержку выражений array[index] внутри фильтров